### PR TITLE
fix: Use Latest Stable Nix Version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,6 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v14
         with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Cachix Install Nix Action will automatically install the latest stable version of Nix. At the time of writing this commit, that is Nix 2.6, which ships with the `flakes` experimental feature