### PR TITLE
readme: add action permission settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ https://github.com/DeterminateSystems/update-flake-lock/ action.
 1. Click "Use this template"
 1. Give it a name, and click "Create repository from template"
 1. Modify the `.github/workflows/update.yml` file to point to your fork's `update-flake-lock` repository and branch
+1. Go to "Settings" → "Actions" → "General" → "Workflow permissions"
+   - Select "Read and write permissions"
+   - Enable "Allow GitHub Actions to create and approve pull requests"
+   - Click "Save"
 1. Go to the "Actions" tab and click on "update-flake-lock"
 1. Then click the "Run workflow" dropdown
 1. Finally, click the "Run workflow" button


### PR DESCRIPTION
When creating a new repo from the template, you must also edit the GitHub Actions workflow permission settings or the workflow job will run into 403 permission errors.

For example, this run (https://github.com/MattSturgeon/test-update-flake-lock/actions/runs/17505282300) has three attempts; during the first the repo settings were left as default, during the second I enabled "allow creating PRs", during the third I also selected "allow write". The third was the only one that didn't 403.

Aside: this should probably also be documented on the main action's [README](https://github.com/DeterminateSystems/update-flake-lock/blob/main/README.md), if it isn't already. It wouldn't apply to anyone using a PAT or a GH App, of course, so that may be worth caveating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README Usage with explicit steps to configure GitHub Actions workflow permissions.
  * Added navigation: Settings → Actions → General → Workflow permissions.
  * Instructed to enable “Read and write permissions” so Actions can create and approve pull requests, then save.
  * Clarified these steps go after modifying the workflow and before visiting the Actions tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->